### PR TITLE
OpenMP+MPI: (fix) ompi_rank_dtype

### DIFF
--- a/src/mptools_ompi.f90
+++ b/src/mptools_ompi.f90
@@ -75,7 +75,7 @@ contains
     if (allocated(dtypes))  deallocate(dtypes)
 
     ! ompi_rank_t
-    count = 4
+    count = 5
     allocate(blklen(count), disp(count), dtypes(count))
     blklen = [ 64,            1,            1,            1,            1            ]
     disp   = [ 0,             64,           68,           72,           76           ]


### PR DESCRIPTION
- Bug fix for the MPI datatype ompi_rank_dtype. The count value was set to 4 while it should have been 5. This has been corrected.