### PR TITLE
General: (feature) OpenMP, MPI and OpenMP+MPI library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,18 +19,18 @@ set(CMAKE_Fortran_STANDARD 2008)
 set(CMAKE_Fortran_STANDARD_REQUIRED ON)
 set(CMAKE_Fortran_MODULE_DIRECTORY ${CMAKE_BINARY_DIR}/modules CACHE PATH "Single directory for all Fortran modules.")
 if (CMAKE_Fortran_COMPILER_ID STREQUAL "GNU")
-  set(CMAKE_Fortran_FLAGS_RELEASE "-O3 -fall-intrinsics -funroll-loops")
-  set(CMAKE_Fortran_FLAGS_DEBUG   "-O0 -std=f2008 -fall-intrinsics -funroll-loops -Wall -Wextra -Warray-temporaries -Wpedantic -Wrealloc-lhs-all -fcheck=all -g")
+  set(CMAKE_Fortran_FLAGS_RELEASE "-O3 -fall-intrinsics -funroll-loops -frecursive")
+  set(CMAKE_Fortran_FLAGS_DEBUG   "-O0 -std=f2008 -fall-intrinsics -funroll-loops -frecursive -Wall -Wextra -Warray-temporaries -Wpedantic -Wrealloc-lhs-all -fcheck=all -g")
 elseif (CMAKE_Fortran_COMPILER_ID STREQUAL "Intel")
   set(CMAKE_Fortran_FLAGS_RELEASE "-O3")
   set(CMAKE_Fortran_FLAGS_DEBUG   "-O0 -warn all -check all")
 endif ()
 
 # OpenMP
-find_package(OpenMP 4.5 REQUIRED)
+find_package(OpenMP 4.5 REQUIRED COMPONENTS Fortran)
 
 # MPI
-find_package(MPI 3.1 REQUIRED)
+find_package(MPI 3.1 REQUIRED COMPONENTS Fortran)
 
 # Doxygen
 if (BUILD_DOC)
@@ -42,9 +42,6 @@ include(GNUInstallDirs)
 
 # Add ptools library itself.
 add_subdirectory(src)
-
-# Add examples.
-#add_subdirectory(examples)
 
 # Install cmake files.
 set(ptools_CONFIG_IN  ${CMAKE_CURRENT_SOURCE_DIR}/cmake/ptools-config.cmake.in)

--- a/cmake/ptools-config.cmake.in
+++ b/cmake/ptools-config.cmake.in
@@ -4,81 +4,132 @@
 # Finds the ptools library, specify the starting search path in ptools_ROOT.
 #
 # Static vs. shared
-# ----------------- 
-# To make use of the static library instead of the shared one, one needs
+# -----------------
+# To make use of the static libraries instead of the shared ones, one needs
 # to set the variable ptools_USE_STATIC_LIBS to ON before calling find_package.
 # Example:
 #   set(ptools_USE_STATIC_LIBS ON)
 #   find_package(ptools CONFIG REQUIRED)
 #
 # There is also the option to make use of the dedicated static and shared
-# ptools librart.
+# ptools libraries.
 #
 # This will define the following variables:
 #
 #   ptools_FOUND     - True if the system has found the ptools libraries
 #   ptools_VERSION   - The version of the ptools library which was found
 #
-# and the following imported targets:
+# and the following imported targets depending on the specified components:
 #
-#   ptools::lib        - The ptools library
-#   ptools::lib_static - The static ptools library
-#   ptools::lib_shared - The shared ptools library
+#   ptools::omp         - The OpenMP ptools library
+#   ptools::omp_static  - The static OpenMP ptools library
+#   ptools::omp_shared  - The shared OpenMP ptools library
+#   ptools::mpi         - The MPI ptools library
+#   ptools::mpi_static  - The static MPI ptools library
+#   ptools::mpi_shared  - The shared MPI ptools library
+#   ptools::ompi        - The OpenMP+MPI ptools library
+#   ptools::ompi_static - The static OpenMP+MPI ptools library
+#   ptools::ompi_shared - The shared OpenMP+MPI ptools library
 
-find_path(ptools_INCLUDE_DIR NAMES mptools.mod DOC "ptools include directory")
-find_library(ptools_static_LIBRARY NAMES libptools.a DOC "Static ptools library")
-find_library(ptools_shared_LIBRARY NAMES libptools.so DOC "Shared ptools library")
-find_program(PTOOLS_PTOOLS name ptools DOC "ptools executable")
+find_path(ptools_INCLUDE_DIR NAMES mptools_omp.mod DOC "ptools include directory")
+find_library(ptools_omp_static_LIBRARY NAMES libptools_omp.a DOC "Static OpenMP ptools library")
+find_library(ptools_omp_shared_LIBRARY NAMES libptools_omp.so DOC "Shared OpenMP ptools library")
+find_library(ptools_mpi_static_LIBRARY NAMES libptools_mpi.a DOC "Static MPI ptools library")
+find_library(ptools_mpi_shared_LIBRARY NAMES libptools_mpi.so DOC "Shared MPI ptools library")
+find_library(ptools_ompi_static_LIBRARY NAMES libptools_ompi.a DOC "Static OpenMP+MPI ptools library")
+find_library(ptools_ompi_shared_LIBRARY NAMES libptools_ompi.so DOC "Shared OpenMP+MPI ptools library")
+find_program(ptools_diag_omp  NAMES diag_omp  DOC "diag_omp executable")
+find_program(ptools_diag_mpi  NAMES diag_mpi  DOC "diag_mpi executable")
+find_program(ptools_diag_ompi NAMES diag_ompi DOC "diag_ompi executable")
 
 # Check version here
-if (ptools_static_LIBRARY)
+if (ptools_omp_static_LIBRARY)
   set(ptools_VERSION @PROJECT_VERSION@)
 endif ()
+
+# Which components have been found.
+set(ptools_omp_FOUND FALSE)
+if (ptools_omp_static_LIBRARY AND ptools_omp_shared_LIBRARY AND ptools_diag_omp)
+  set(ptools_omp_FOUND TRUE)
+endif ()
+set(ptools_mpi_FOUND FALSE)
+if (ptools_mpi_static_LIBRARY AND ptools_mpi_shared_LIBRARY AND ptools_diag_mpi)
+  set(ptools_mpi_FOUND TRUE)
+endif ()
+set(ptools_ompi_FOUND FALSE)
+if (ptools_ompi_static_LIBRARY AND ptools_ompi_shared_LIBRARY AND ptools_diag_ompi)
+  set(ptools_ompi_FOUND TRUE)
+endif ()
+
+# Check if at least one component has been specified.
+list(LENGTH ptools_FIND_COMPONENTS ptools_NCOMPONENTS)
+if (ptools_NCOMPONENTS LESS 1)
+  message(FATAL_ERROR "No components have been specified. This is not allowed. Please, specify at least one of the components omp, mpi or ompi.")
+endif ()
+unset(ptools_NCOMPONENTS)
 
 include(FindPackageHandleStandardArgs)
 set(${CMAKE_FIND_PACKAGE_NAME}_CONFIG "${CMAKE_CURRENT_LIST_FILE}")
 find_package_handle_standard_args(ptools
   FOUND_VAR ptools_FOUND
-  REQUIRED_VARS ptools_static_LIBRARY ptools_shared_LIBRARY ptools_INCLUDE_DIR ptools_PTOOLS
+  REQUIRED_VARS ptools_INCLUDE_DIR ptools_diag_omp ptools_diag_mpi ptools_diag_ompi
+  HANDLE_COMPONENTS
   VERSION_VAR ptools_VERSION
   CONFIG_MODE
 )
 
 if (ptools_FOUND)
-  # Static library
-  add_library(ptools::lib_static STATIC IMPORTED)
-  set_target_properties(ptools::lib_static PROPERTIES
-    IMPORTED_LOCATION "${ptools_static_LIBRARY}"
-    INTERFACE_INCLUDE_DIRECTORIES "${ptools_INCLUDE_DIR}"
-  )
+  foreach (component ${ptools_FIND_COMPONENTS})
+    set(ptools_LINK_LIBRARIES)
+    if ("${component}" STREQUAL "omp" OR "${component}" STREQUAL "ompi")
+      find_package(OpenMP 4.5 QUIET REQUIRED COMPONENTS Fortran)
+      list(APPEND ptools_LINK_LIBRARIES "OpenMP::OpenMP_Fortran")
+    endif ()
+    if ("${component}" STREQUAL "mpi" OR "${component}" STREQUAL "ompi")
+      find_package(MPI 3.1 QUIET REQUIRED COMPONENTS Fortran)
+      list(APPEND ptools_LINK_LIBRARIES "MPI::MPI_Fortran")
+    endif ()
 
-  # Shared library
-  add_library(ptools::lib_shared SHARED IMPORTED)
-  set_target_properties(ptools::lib_shared PROPERTIES
-    IMPORTED_LOCATION "${ptools_shared_LIBRARY}"
-    INTERFACE_INCLUDE_DIRECTORIES "${ptools_INCLUDE_DIR}"
-  )
-  
-  if(ptools_USE_STATIC_LIBS)
-    add_library(ptools::lib ALIAS ptools::lib_static)
-    set(ptools_LIBRARY ${ptools_static_LIBRARY)
-  else()
-    add_library(ptools::lib ALIAS ptools::lib_shared)
-    set(ptools_LIBRARY ${ptools_shared_LIBRARY)
-  endif()
+    # Static library
+    add_library(ptools::${component}_static STATIC IMPORTED)
+    set_target_properties(ptools::${component}_static PROPERTIES
+      IMPORTED_LOCATION "${ptools_${component}_static_LIBRARY}"
+      INTERFACE_LINK_LIBRARIES "${ptools_LINK_LIBRARIES}"
+      INTERFACE_INCLUDE_DIRECTORIES "${ptools_INCLUDE_DIR}"
+    )
 
-  # Executable
-  add_executable(ptools::pdiag IMPORTED)
-  set_target_properties(ptools::pdiag PROPERTIES
-    IMPORTED_LOCATION "${ptools_shared_LIBRARY}"
-    INTERFACE_INCLUDE_DIRECTORIES "${ptools_INCLUDE_DIR}"
-  )
-  
+    # Shared library
+    add_library(ptools::${component}_shared SHARED IMPORTED)
+    set_target_properties(ptools::${component}_shared PROPERTIES
+      IMPORTED_LOCATION "${ptools_${component}_shared_LIBRARY}"
+      INTERFACE_LINK_LIBRARIES "${ptools_LINK_LIBRARIES}"
+      INTERFACE_INCLUDE_DIRECTORIES "${ptools_INCLUDE_DIR}"
+    )
+
+    if (ptools_USE_STATIC_LIBS)
+      add_library(ptools::${component} ALIAS ptools::${component}_static)
+      set(ptools_${component}_LIBRARY ${ptools_${component}_static_LIBRARY})
+    else ()
+      add_library(ptools::${component} ALIAS ptools::${component}_shared)
+      set(ptools_${component}_LIBRARY ${ptools_${component}_shared_LIBRARY})
+    endif ()
+
+    unset(ptools_LINK_LIBRARIES)
+  endforeach ()
 endif()
 
 mark_as_advanced(
-  ptools_static_LIBRARY
-  ptools_shared_LIBRARY
-  ptools_LIBRARY
+  ptools_omp_LIBRARY
+  ptools_omp_static_LIBRARY
+  ptools_omp_shared_LIBRARY
+  ptools_mpi_static_LIBRARY
+  ptools_mpi_LIBRARY
+  ptools_mpi_shared_LIBRARY
+  ptools_ompi_LIBRARY
+  ptools_ompi_static_LIBRARY
+  ptools_ompi_shared_LIBRARY
+  ptools_diag_omp
+  ptools_diag_mpi
+  ptools_diag_ompi
   ptools_INCLUDE_DIR
 )

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -6,57 +6,108 @@ set(PTOOLS_CONFIG_IN  ${CMAKE_CURRENT_SOURCE_DIR}/mptools_version.f90.in)
 set(PTOOLS_CONFIG_OUT ${CMAKE_CURRENT_BINARY_DIR}/mptools_version.f90)
 configure_file(${PTOOLS_CONFIG_IN} ${PTOOLS_CONFIG_OUT} @ONLY)
 
-set(PTOOLSLIB_SRC ${PTOOLS_SRCDIR}/mptools.f90
-                  ${PTOOLS_SRCDIR}/mptools_mpi.f90
-                  ${PTOOLS_SRCDIR}/mptools_omp.f90
-                  ${PTOOLS_SRCDIR}/mptools_ompi.f90
-                  ${PTOOLS_SRCDIR}/mptools_parameters.f90
-                  ${PTOOLS_SRCDIR}/mptools_system.f90
-	          ${PTOOLS_BINDIR}/mptools_version.f90)
-
-set(DIAGMPI_SRC ${PTOOLS_SRCDIR}/diag_mpi.f90)
-set(DIAGOMP_SRC ${PTOOLS_SRCDIR}/diag_omp.f90)
+set(PTOOLSLIB_SRC      ${PTOOLS_SRCDIR}/mptools_parameters.f90
+                       ${PTOOLS_SRCDIR}/mptools_system.f90
+	               ${PTOOLS_BINDIR}/mptools_version.f90)
+set(PTOOLSLIB_OMP_SRC  ${PTOOLS_SRCDIR}/mptools_omp.f90)
+set(PTOOLSLIB_MPI_SRC  ${PTOOLS_SRCDIR}/mptools_mpi.f90)
+set(PTOOLSLIB_OMPI_SRC ${PTOOLS_SRCDIR}/mptools_ompi.f90)
+		
+set(DIAGMPI_SRC  ${PTOOLS_SRCDIR}/diag_mpi.f90)
+set(DIAGOMP_SRC  ${PTOOLS_SRCDIR}/diag_omp.f90)
 set(DIAGOMPI_SRC ${PTOOLS_SRCDIR}/diag_ompi.f90)
 
 # Fortran module directory
 set(PTOOLS_Fortran_MODDIR ${CMAKE_CURRENT_BINARY_DIR}/modules)
 
-# Object library
+# --- Object libraries ---
+# Object library: General
 add_library(ptoolslib_obj OBJECT ${PTOOLSLIB_SRC})
 set_target_properties(ptoolslib_obj PROPERTIES POSITION_INDEPENDENT_CODE ON)
 set_target_properties(ptoolslib_obj PROPERTIES Fortran_MODULE_DIRECTORY ${PTOOLS_Fortran_MODDIR})
 target_include_directories(ptoolslib_obj PUBLIC ${PTOOLS_Fortran_MODDIR})
-target_link_libraries(ptoolslib_obj MPI::MPI_Fortran OpenMP::OpenMP_Fortran)
 
-# Static library
-add_library(ptoolslib_static STATIC "$<TARGET_OBJECTS:ptoolslib_obj>")
-set_target_properties(ptoolslib_static PROPERTIES OUTPUT_NAME ptools)
-target_link_libraries(ptoolslib_static ptoolslib_obj)
-install(TARGETS ptoolslib_static
+# Object library: OpenMP
+add_library(ptoolslib_omp_obj OBJECT ${PTOOLSLIB_OMP_SRC})
+set_target_properties(ptoolslib_omp_obj PROPERTIES POSITION_INDEPENDENT_CODE ON)
+set_target_properties(ptoolslib_omp_obj PROPERTIES Fortran_MODULE_DIRECTORY ${PTOOLS_Fortran_MODDIR})
+target_include_directories(ptoolslib_omp_obj PUBLIC ${PTOOLS_Fortran_MODDIR})
+target_link_libraries(ptoolslib_omp_obj ptoolslib_obj OpenMP::OpenMP_Fortran)
+
+# Object library: MPI
+add_library(ptoolslib_mpi_obj OBJECT ${PTOOLSLIB_MPI_SRC})
+set_target_properties(ptoolslib_mpi_obj PROPERTIES POSITION_INDEPENDENT_CODE ON)
+set_target_properties(ptoolslib_mpi_obj PROPERTIES Fortran_MODULE_DIRECTORY ${PTOOLS_Fortran_MODDIR})
+target_include_directories(ptoolslib_mpi_obj PUBLIC ${PTOOLS_Fortran_MODDIR})
+target_link_libraries(ptoolslib_mpi_obj ptoolslib_obj MPI::MPI_Fortran)
+
+# Object library: OpenMP+MPI
+add_library(ptoolslib_ompi_obj OBJECT ${PTOOLSLIB_OMPI_SRC})
+set_target_properties(ptoolslib_ompi_obj PROPERTIES POSITION_INDEPENDENT_CODE ON)
+set_target_properties(ptoolslib_ompi_obj PROPERTIES Fortran_MODULE_DIRECTORY ${PTOOLS_Fortran_MODDIR})
+target_include_directories(ptoolslib_ompi_obj PUBLIC ${PTOOLS_Fortran_MODDIR})
+target_link_libraries(ptoolslib_ompi_obj ptoolslib_obj OpenMP::OpenMP_Fortran MPI::MPI_Fortran)
+
+# --- Static libraries ---
+# Static library: OpenMP
+add_library(ptoolslib_omp_static STATIC "$<TARGET_OBJECTS:ptoolslib_omp_obj>" "$<TARGET_OBJECTS:ptoolslib_obj>")
+set_target_properties(ptoolslib_omp_static PROPERTIES OUTPUT_NAME ptools_omp)
+target_link_libraries(ptoolslib_omp_static ptoolslib_omp_obj OpenMP::OpenMP_Fortran)
+install(TARGETS ptoolslib_omp_static
         ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
 
-# Shared library
-add_library(ptoolslib_shared SHARED "$<TARGET_OBJECTS:ptoolslib_obj>")
-set_target_properties(ptoolslib_shared PROPERTIES OUTPUT_NAME ptools)
-target_link_libraries(ptoolslib_shared ptoolslib_obj)
-install(TARGETS ptoolslib_shared
+# Static library: MPI
+add_library(ptoolslib_mpi_static STATIC "$<TARGET_OBJECTS:ptoolslib_mpi_obj>" "$<TARGET_OBJECTS:ptoolslib_obj>")
+set_target_properties(ptoolslib_mpi_static PROPERTIES OUTPUT_NAME ptools_mpi)
+target_link_libraries(ptoolslib_mpi_static ptoolslib_mpi_obj MPI::MPI_Fortran)
+install(TARGETS ptoolslib_mpi_static
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
+
+# Static library: OpenMP+MPI
+add_library(ptoolslib_ompi_static STATIC "$<TARGET_OBJECTS:ptoolslib_ompi_obj>" "$<TARGET_OBJECTS:ptoolslib_omp_obj>" "$<TARGET_OBJECTS:ptoolslib_obj>")
+set_target_properties(ptoolslib_ompi_static PROPERTIES OUTPUT_NAME ptools_ompi)
+target_link_libraries(ptoolslib_ompi_static ptoolslib_ompi_obj OpenMP::OpenMP_Fortran MPI::MPI_Fortran)
+install(TARGETS ptoolslib_ompi_static
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
+
+# --- Shared libraries ---
+# Shared library: OpenMP
+add_library(ptoolslib_omp_shared SHARED "$<TARGET_OBJECTS:ptoolslib_omp_obj>" "$<TARGET_OBJECTS:ptoolslib_obj>")
+set_target_properties(ptoolslib_omp_shared PROPERTIES OUTPUT_NAME ptools_omp)
+target_link_libraries(ptoolslib_omp_shared ptoolslib_obj OpenMP::OpenMP_Fortran)
+install(TARGETS ptoolslib_omp_shared
         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
 
+# Shared library: MPI
+add_library(ptoolslib_mpi_shared SHARED "$<TARGET_OBJECTS:ptoolslib_mpi_obj>" "$<TARGET_OBJECTS:ptoolslib_obj>")
+set_target_properties(ptoolslib_mpi_shared PROPERTIES OUTPUT_NAME ptools_mpi)
+target_link_libraries(ptoolslib_mpi_shared ptoolslib_obj MPI::MPI_Fortran)
+install(TARGETS ptoolslib_mpi_shared
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
+
+# Shared library: OpenMP+MPI
+add_library(ptoolslib_ompi_shared SHARED "$<TARGET_OBJECTS:ptoolslib_ompi_obj>" "$<TARGET_OBJECTS:ptoolslib_omp_obj>" "$<TARGET_OBJECTS:ptoolslib_obj>")
+set_target_properties(ptoolslib_ompi_shared PROPERTIES OUTPUT_NAME ptools_ompi)
+target_link_libraries(ptoolslib_ompi_shared ptoolslib_omp_obj ptoolslib_obj OpenMP::OpenMP_Fortran MPI::MPI_Fortran)
+install(TARGETS ptoolslib_ompi_shared
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
+
+# --- Executables ---
 # Executable: diag_omp
 add_executable(diag_omp ${DIAGOMP_SRC})
-target_link_libraries(diag_omp ptoolslib_static)
+target_link_libraries(diag_omp ptoolslib_omp_static)
 install(TARGETS diag_omp
         RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
 
 # Executable: diag_mpi
 add_executable(diag_mpi ${DIAGMPI_SRC})
-target_link_libraries(diag_mpi ptoolslib_static MPI::MPI_Fortran)
+target_link_libraries(diag_mpi ptoolslib_mpi_static MPI::MPI_Fortran)
 install(TARGETS diag_mpi
         RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
 
 # Executable: diag_ompi
 add_executable(diag_ompi ${DIAGOMPI_SRC})
-target_link_libraries(diag_ompi ptoolslib_static MPI::MPI_Fortran)
+target_link_libraries(diag_ompi ptoolslib_ompi_static MPI::MPI_Fortran)
 install(TARGETS diag_ompi
         RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
 
@@ -68,8 +119,7 @@ install(PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/show_setup.bsh
         DESTINATION ${CMAKE_INSTALL_BINDIR})
 
 # Install Fortran module files
-install(FILES ${PTOOLS_Fortran_MODDIR}/mptools.mod
-              ${PTOOLS_Fortran_MODDIR}/mptools_mpi.mod
+install(FILES ${PTOOLS_Fortran_MODDIR}/mptools_mpi.mod
               ${PTOOLS_Fortran_MODDIR}/mptools_omp.mod
               ${PTOOLS_Fortran_MODDIR}/mptools_ompi.mod
               ${PTOOLS_Fortran_MODDIR}/mptools_parameters.mod

--- a/src/diag_mpi.f90
+++ b/src/diag_mpi.f90
@@ -1,7 +1,7 @@
 !> \brief The program diag_mpi analyses the MPI configuration of the current environment.
 program diag_mpi
   use, intrinsic :: iso_fortran_env, only: error_unit, int32
-  use            :: mpi_f08,         only: MPI_COMM_WORLD, MPI_Comm_rank
+  use            :: mpi_f08,         only: MPI_COMM_WORLD, MPI_Comm_rank, MPI_Finalize, MPI_Init
   use            :: mptools_mpi,     only: mpi_t, mpi_rank_t, mpi_analysis, mpi_report
   implicit none
 

--- a/src/diag_ompi.f90
+++ b/src/diag_ompi.f90
@@ -1,7 +1,7 @@
 !> \brief The program diag_ompi analyses the OpenMP+MPI configuration of the current environment.
 program diag_ompi
   use, intrinsic :: iso_fortran_env, only: error_unit, int32
-  use            :: mpi_f08,         only: MPI_COMM_WORLD,MPI_Comm_rank
+  use            :: mpi_f08,         only: MPI_COMM_WORLD, MPI_Comm_rank, MPI_Finalize, MPI_Init
   use            :: mptools_ompi,    only: ompi_t, ompi_rank_t, ompi_analysis, ompi_report
   implicit none
 

--- a/src/mptools_mpi.f90
+++ b/src/mptools_mpi.f90
@@ -3,7 +3,7 @@
 module mptools_mpi
   use, intrinsic :: iso_fortran_env,     only: int32
   use, intrinsic :: iso_c_binding
-  use            :: mptools_parameters,  only: NAME_SIZE
+  use            :: mptools_parameters,  only: NAME_SIZE, STR_SIZE, MAX_THREADS
   implicit none
 
   private

--- a/src/mptools_omp.f90
+++ b/src/mptools_omp.f90
@@ -1,8 +1,9 @@
 !> \brief Module containing parameters, functions and subroutines for analyzing
 !!        the OpenMP configuration.
 module mptools_omp
-  use, intrinsic :: iso_fortran_env, only: int32
-  use, intrinsic :: omp_lib_kinds,   only: OMP_PROC_BIND_KIND, OMP_SCHED_KIND
+  use, intrinsic :: iso_fortran_env,     only: int32
+  use, intrinsic :: omp_lib_kinds,       only: OMP_PROC_BIND_KIND, OMP_SCHED_KIND
+  use            :: mptools_parameters,  only: NAME_SIZE, STR_SIZE, MAX_THREADS
   implicit none
 
   private
@@ -47,9 +48,8 @@ contains
   !> \cond _INTERNAL_
   !> \brief Get the OpenMP schedule string.
   function get_omp_schedule_type(schedule_id) result(schedule)
-    use, intrinsic :: iso_fortran_env,     only: int32
-    use, intrinsic :: omp_lib_kinds,       only: OMP_SCHED_STATIC, OMP_SCHED_DYNAMIC, OMP_SCHED_GUIDED, OMP_SCHED_AUTO
-    use            :: mptools_parameters,  only: STR_SIZE
+    use, intrinsic :: iso_fortran_env,  only: int32
+    use, intrinsic :: omp_lib_kinds,    only: OMP_SCHED_STATIC, OMP_SCHED_DYNAMIC, OMP_SCHED_GUIDED, OMP_SCHED_AUTO
 
     integer(OMP_SCHED_KIND), intent(in) :: schedule_id  !< OpenMP schedule identification number.
     character(len=STR_SIZE)             :: schedule     !< Schedule type as string.
@@ -72,10 +72,9 @@ contains
   !> \cond _INTERNAL_
   !> \brief Get the OpenMP schedule string.
   function get_omp_proc_bind_type(bind_id) result(bind)
-    use, intrinsic :: iso_fortran_env,     only: int32
-    use, intrinsic :: omp_lib,             only: OMP_PROC_BIND_FALSE, OMP_PROC_BIND_TRUE, OMP_PROC_BIND_MASTER,  &
-                                                 OMP_PROC_BIND_CLOSE, OMP_PROC_BIND_SPREAD
-    use            :: mptools_parameters,  only: STR_SIZE
+    use, intrinsic :: iso_fortran_env,  only: int32
+    use, intrinsic :: omp_lib,          only: OMP_PROC_BIND_FALSE, OMP_PROC_BIND_TRUE, OMP_PROC_BIND_MASTER,  &
+                                              OMP_PROC_BIND_CLOSE, OMP_PROC_BIND_SPREAD
 
     integer(OMP_PROC_BIND_KIND), intent(in) :: bind_id  !< OpenMP thread affinity identification number.
     character(len=STR_SIZE)                 :: bind     !< Thread affinity type as string.

--- a/src/mptools_ompi.f90
+++ b/src/mptools_ompi.f90
@@ -3,7 +3,7 @@
 module mptools_ompi
   use, intrinsic :: iso_fortran_env,     only: int32
   use, intrinsic :: omp_lib_kinds,       only: OMP_PROC_BIND_KIND, OMP_SCHED_KIND
-  use            :: mptools_parameters,  only: NAME_SIZE
+  use            :: mptools_parameters,  only: NAME_SIZE, STR_SIZE, MAX_THREADS
   implicit none
 
   private
@@ -107,12 +107,11 @@ contains
   !> \cond _INTERNAL_
   !> \brief Perform the OpenMP+MPI analysis for a rank.
   function ompi_rank_analysis(ompi_info, rank_info) result(valid)
-    use, intrinsic :: iso_fortran_env,     only: int32
-    use            :: mpi_f08,             only: MPI_COMM_WORLD,                                 &
-                                                 MPI_Comm_rank, MPI_Comm_size, MPI_Get_version
-    use            :: mptools_omp,         only: omp_t, omp_thread_t, omp_analysis
-    use            :: mptools_parameters,  only: MAX_THREADS, NAME_SIZE
-    use            :: mptools_system,      only: get_hostname
+    use, intrinsic :: iso_fortran_env,  only: int32
+    use            :: mpi_f08,          only: MPI_COMM_WORLD,                                 &
+                                              MPI_Comm_rank, MPI_Comm_size, MPI_Get_version
+    use            :: mptools_omp,      only: omp_t, omp_thread_t, omp_analysis
+    use            :: mptools_system,   only: get_hostname
 
     type(ompi_t),                    intent(out) :: ompi_info  !< General OMPI information.
     type(ompi_rank_t), dimension(:), intent(out) :: rank_info  !< OMPI rank information.
@@ -168,9 +167,8 @@ contains
   !!
   !! \warning Be aware, the variable \p rank_info will only be allocated for rank 0.
   subroutine ompi_analysis(ompi_info, rank_info)
-    use :: mpi_f08,             only: MPI_COMM_WORLD, MPI_Datatype, MPI_Status,          &
-                                      MPI_Comm_size, MPI_Comm_rank, MPI_Recv, MPI_Send
-    use :: mptools_parameters,  only: MAX_THREADS
+    use :: mpi_f08,  only: MPI_COMM_WORLD, MPI_Datatype, MPI_Status,          &
+                           MPI_Comm_size, MPI_Comm_rank, MPI_Recv, MPI_Send
 
     type(ompi_t),                                 intent(out) :: ompi_info  !< General OMPI information.
     type(ompi_rank_t), dimension(:), allocatable, intent(out) :: rank_info  !< OMPI rank information.


### PR DESCRIPTION
- Splitted the library in three separate libraries, one for OpenMP, MPI and OpenMP+MPI application. This is done to avoid undesired dependepencies. For example, a purely OpenMP application should not depend on MPI via the ptools library.
- Updated the ptools CMake config file.