### PR TITLE
OpenMP: (fix) Dynamic array

### DIFF
--- a/dox/main.dox
+++ b/dox/main.dox
@@ -25,19 +25,16 @@
  *
  * \code{.f90}
  * subroutine analyze_openmp()
- *   use :: mptools_omp,         only: omp_t, omp_thread_t, omp_analysis, omp_report
- *   use :: mptools_parameters,  only: MAX_THREADS
+ *   use :: mptools_omp,  only: omp_t, omp_thread_t, omp_analysis, omp_report
  * 
  *   ! Locals
- *   type(omp_t)                                :: omp_info
- *   type(omp_thread_t), dimension(MAX_THREADS) :: thread_info
+ *   type(omp_t)                                   :: omp_info
+ *   type(omp_thread_t), dimension(:), allocatable :: thread_info
  * 
- *   if (omp_analysis(omp_info, thread_info)) then
- *      call omp_report(omp_info, thread_info)
- *   else
- *      write(error_unit,'(A)') "*** ERROR: Unable to create OpenMP analysis report"
- *      error stop 1
- *   end if
+ *   call omp_analysis(omp_info, thread_info)
+ *   call omp_report(omp_info, thread_info)
+ *
+ *   if (allocated(thread_info))  deallocate(thread_info)
  * end subroutine analyze_openmp
  * \endcode
  *

--- a/src/diag_omp.f90
+++ b/src/diag_omp.f90
@@ -1,18 +1,15 @@
 !> \brief The program diag_omp analyses the OpenMP configuration of the current environment.
 program diag_omp
-  use, intrinsic :: iso_fortran_env,     only: error_unit
-  use            :: mptools_omp,         only: omp_t, omp_thread_t, omp_analysis, omp_report
-  use            :: mptools_parameters,  only: MAX_THREADS
+  use, intrinsic :: iso_fortran_env,  only: error_unit
+  use            :: mptools_omp,      only: omp_t, omp_thread_t, omp_analysis, omp_report
   implicit none
 
   ! Locals
-  type(omp_t)                                :: omp_info
-  type(omp_thread_t), dimension(MAX_THREADS) :: thread_info
+  type(omp_t)                                   :: omp_info
+  type(omp_thread_t), dimension(:), allocatable :: thread_info
 
-  if (omp_analysis(omp_info, thread_info)) then
-     call omp_report(omp_info, thread_info)
-  else
-     write(error_unit,'(A)') "*** ERROR: Unable to create OpenMP analysis report"
-     error stop 1
-  end if
+  call omp_analysis(omp_info, thread_info)
+  call omp_report(omp_info, thread_info)
+
+  if (allocated(thread_info))  deallocate(thread_info)
 end program diag_omp

--- a/src/mptools_mpi.f90
+++ b/src/mptools_mpi.f90
@@ -3,7 +3,7 @@
 module mptools_mpi
   use, intrinsic :: iso_fortran_env,     only: int32
   use, intrinsic :: iso_c_binding
-  use            :: mptools_parameters,  only: NAME_SIZE, STR_SIZE, MAX_THREADS
+  use            :: mptools_parameters,  only: NAME_SIZE, STR_SIZE
   implicit none
 
   private
@@ -153,6 +153,7 @@ contains
     call MPI_Comm_size(MPI_COMM_WORLD, nranks)
     call MPI_Comm_rank(MPI_COMM_WORLD, irank)
     if (irank == 0) then
+       if (allocated(rank_info))  deallocate(rank_info)
        allocate(rank_info(nranks))
 
        valid = mpi_rank_analysis(mpi_info, info)

--- a/src/mptools_parameters.f90
+++ b/src/mptools_parameters.f90
@@ -1,12 +1,10 @@
 module mptools_parameters
-  use, intrinsic :: iso_fortran_env, only: int32, int64
+  use, intrinsic :: iso_fortran_env,  only: int64
   implicit none
 
   private
 
   ! General
-  integer(int64), parameter, public :: NAME_SIZE   =  64  !< Maximum string lenght of the hostname.
-  integer(int64), parameter, public :: STR_SIZE    = 256  !< Maximum size of a string.
-  integer(int32), parameter, public :: MAX_THREADS = 512  !< Maximum number of threads.
-  
+  integer(int64), parameter, public :: NAME_SIZE =  64  !< Maximum string lenght of the hostname.
+  integer(int64), parameter, public :: STR_SIZE  = 256  !< Maximum size of a string.
 end module mptools_parameters


### PR DESCRIPTION
- Changed the OpenMP implementation such that the thread_info array is now an array of dynamic size instead of fixed sized array. This change is more inline with the MPI and OpenMP+MPI implementation,